### PR TITLE
Fixed allowed setups check on run-remote

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.10.3"
+version = "0.10.4"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"

--- a/redisbench_admin/run_remote/run_remote.py
+++ b/redisbench_admin/run_remote/run_remote.py
@@ -362,7 +362,12 @@ def run_remote_command_logic(args, project_name, project_version):
                             shard_count,
                         ) = get_setup_type_and_primaries_count(setup_settings)
                         if args.allowed_setups != "":
-                            allowed_setups = args.allowed_setups.split()
+                            allowed_setups = args.allowed_setups.split(",")
+                            logging.info(
+                                "Checking if setup named {} of topology type {}. Total primaries: {} is in the allowed list of setups {}".format(
+                                    setup_name, setup_type, shard_count, allowed_setups
+                                )
+                            )
                             if setup_name not in allowed_setups:
                                 logging.warning(
                                     "SKIPPING setup named {} of topology type {}.".format(


### PR DESCRIPTION
on run-remote allowed_setups was not being split by comma, which made any check of more than one setup not work.
