### PR TITLE
Fix for TypeError

### DIFF
--- a/redisbench_admin/run/common.py
+++ b/redisbench_admin/run/common.py
@@ -421,9 +421,8 @@ def execute_init_commands(benchmark_config, r, dbconfig_keyname="dbconfig"):
     cmds = None
     res = 0
     if dbconfig_keyname in benchmark_config:
-        for k in benchmark_config[dbconfig_keyname]:
-            if "init_commands" in k:
-                cmds = k["init_commands"]
+        if "init_commands" in benchmark_config[dbconfig_keyname]:
+            cmds = benchmark_config[dbconfig_keyname]["init_commands"]
     if cmds is not None:
         for cmd in cmds:
             is_array = False


### PR DESCRIPTION
Fix for error:
```Traceback (most recent call last):
  File "/root/venv-redis/lib/python3.8/site-packages/redis_benchmarks_specification/__self_contained_coordinator__/self_contained_coordinator.py", line 560, in process_self_contained_coordinator_stream
    execute_init_commands(
  File "/root/venv-redis/lib/python3.8/site-packages/redisbench_admin/run/common.py", line 426, in execute_init_commands
    cmds = k["init_commands"]
TypeError: string indices must be integers
```

### How to reproduce:
Run on testing host: 
```
$ redis-benchmarks-spec-sc-coordinator --platform-name intel64-ubuntu20.04-biredis --event_stream_host benchmarks.redislabs.com --event_stream_port 12010 --event_stream_pass <redacted!!!> --event_stream_user default --datasink_push_results_redistimeseries --datasink_redistimeseries_host benchmarks.redislabs.com --datasink_redistimeseries_port 12011 --datasink_redistimeseries_pass <redacted!!!> --logname /var/opt/test2.log --redis_proc_start_port 6379 --cpuset_start_pos 0 --docker-air-gap --consumer-id 1
```
In parallell run testing's triggering:
```
redis-benchmarks-spec-cli --use-branch --from-date 2023-03-22 --redis_port 12010 --redis_host benchmarks.redislabs.com --redis_pass ***
```