### PR TITLE
Allow to skip module artifact check/errors

### DIFF
--- a/redisbench_admin/run_remote/args.py
+++ b/redisbench_admin/run_remote/args.py
@@ -119,5 +119,11 @@ def create_run_remote_arguments(parser):
         action="store_true",
         help="skip environment variables check",
     )
+    parser.add_argument(
+        "--continue-on-module-check-error",
+        default=False,
+        action="store_true",
+        help="Continue running benchmarks even if module check failed",
+    )
 
     return parser

--- a/redisbench_admin/run_remote/remote_db.py
+++ b/redisbench_admin/run_remote/remote_db.py
@@ -102,6 +102,7 @@ def remote_db_spin(
     redis_password=None,
     flushall_on_every_test_start=False,
     ignore_keyspace_errors=False,
+    continue_on_module_check_error=False,
 ):
     (
         _,
@@ -131,6 +132,7 @@ def remote_db_spin(
             remote_module_file_dir,
             server_public_ip,
             username,
+            continue_on_module_check_error,
         )
     # setup Redis
     redis_setup_result = True
@@ -228,6 +230,11 @@ def remote_db_spin(
                 temporary_dir,
                 True,
                 username,
+            )
+            raise Exception(
+                "A error occurred while spinning DB: {}. Aborting...".format(
+                    e.__str__()
+                )
             )
 
     if cluster_enabled and skip_redis_setup is False:

--- a/redisbench_admin/run_remote/standalone.py
+++ b/redisbench_admin/run_remote/standalone.py
@@ -72,6 +72,7 @@ def remote_module_files_cp(
     remote_module_file_dir,
     server_public_ip,
     username,
+    continue_on_module_check_error=False,
 ):
     remote_module_files = []
     if local_module_files is not None:
@@ -99,7 +100,7 @@ def remote_module_files_cp(
                     os.path.basename(local_module_file_and_plugin),
                 )
                 # copy the module to the DB machine
-                copy_file_to_remote_setup(
+                cp_res = copy_file_to_remote_setup(
                     server_public_ip,
                     username,
                     private_key,
@@ -107,14 +108,16 @@ def remote_module_files_cp(
                     remote_module_file,
                     None,
                     port,
+                    continue_on_module_check_error,
                 )
-                execute_remote_commands(
-                    server_public_ip,
-                    username,
-                    private_key,
-                    ["chmod 755 {}".format(remote_module_file)],
-                    port,
-                )
+                if cp_res:
+                    execute_remote_commands(
+                        server_public_ip,
+                        username,
+                        private_key,
+                        ["chmod 755 {}".format(remote_module_file)],
+                        port,
+                    )
                 if pos > 1:
                     remote_module_files_in = remote_module_files_in + " "
                 remote_module_files_in = remote_module_files_in + remote_module_file

--- a/redisbench_admin/utils/remote.py
+++ b/redisbench_admin/utils/remote.py
@@ -63,8 +63,10 @@ def copy_file_to_remote_setup(
     remote_file,
     dirname=None,
     port=22,
+    continue_on_module_check_error=False,
 ):
     full_local_path = local_file
+    res = False
     if dirname is not None:
         full_local_path = "{}/{}".format(dirname, local_file)
     logging.info(
@@ -94,12 +96,20 @@ def copy_file_to_remote_setup(
         )
         res = True
     else:
-        logging.error(
-            "Local file {} does not exists. aborting...".format(full_local_path)
-        )
-        raise Exception(
-            "Local file {} does not exists. aborting...".format(full_local_path)
-        )
+        if continue_on_module_check_error:
+            logging.warning(
+                "Continuing running benchmarks after module check failed on file: {}. Full path {}".format(
+                    local_file, full_local_path
+                )
+            )
+        else:
+            logging.error(
+                "Local file {} does not exists. aborting...".format(full_local_path)
+            )
+
+            raise Exception(
+                "Local file {} does not exists. aborting...".format(full_local_path)
+            )
     return res
 
 


### PR DESCRIPTION
Introduce a new option in run-remote to avoid raising expection on unexisting module artifacts: `--continue-on-module-check-error` 
This is specifically designed for addition of config arg on RedisGears named `v8-plugin-path` https://github.com/RedisGears/RedisGears/actions/runs/4816673701/jobs/8576546334