### PR TITLE
run: accept --running_platform so platforms get separate series

### DIFF
--- a/redisbench_admin/run/args.py
+++ b/redisbench_admin/run/args.py
@@ -65,6 +65,17 @@ def common_run_args(parser):
         help=f"Architecture to run the benchmark on. One of {VALID_ARCHS}.",
     )
     parser.add_argument(
+        "--running_platform",
+        type=str,
+        required=False,
+        default=None,
+        help="Platform identifier recorded in the time-series key and labels, "
+        "for example the instance class the benchmark ran on. Without it, runs "
+        "on different hardware share a single series, because labels are "
+        "per-series rather than per-sample and get overwritten by the latest "
+        "push. Set it to keep results from different platforms separable.",
+    )
+    parser.add_argument(
         "--keep_env_and_topo",
         required=False,
         default=KEEP_ENV,

--- a/redisbench_admin/run_local/run_local.py
+++ b/redisbench_admin/run_local/run_local.py
@@ -703,6 +703,7 @@ def run_local_command_logic(args, project_name, project_version):
                                     github_repo_name,
                                     tf_triggering_env,
                                     metadata_tags,
+                                    running_platform=args.running_platform,
                                     tf_github_sha=push_github_sha,
                                     arch=push_arch,
                                 )

--- a/redisbench_admin/run_remote/run_remote.py
+++ b/redisbench_admin/run_remote/run_remote.py
@@ -1479,6 +1479,7 @@ def run_remote_command_logic(args, project_name, project_version):
                                             tf_github_repo,
                                             tf_triggering_env,
                                             metadata_tags,
+                                            running_platform=args.running_platform,
                                             tf_github_sha=push_github_sha,
                                             arch=push_arch,
                                         )


### PR DESCRIPTION
## Problem

`running_platform` is already:

- part of the time-series key, in `get_ts_metric_name` (`utils/utils.py`)
- a label, in `get_project_ts_tags` (`utils/remote.py`)
- threaded through `common_exporter_logic` and `timeseries_test_sucess_flow`
- filterable in `compare`, via `--running_platform` (`compare/args.py`)

Only the run entry points never supply it. `run_remote.py` and `run_local.py` both
call `timeseries_test_sucess_flow` without it, and no run argument exists to set
it, so in practice it is always `None`.

The consequence is that benchmark runs on different hardware share a single
series. Tagging cannot substitute for this: `check_rts_labels` applies `TS.ALTER`
whenever incoming labels differ from the key's, so labels describe the *series*
and the most recent push wins. Provenance cannot be recovered per sample.

Observed while building regression coverage for RediSearch: an `m7i.8xlarge` VM
baseline and an `m7i.metal-24xl` run against the same commit read back as one
8-sample series. Its confidence interval converged happily, around a mean that
described neither platform. Nothing on the surface looked wrong.

## Change

Adds `--running_platform` to `common_run_args`, beside `--architecture` — its
closest analogue, since both describe the machine the benchmark ran on and both
belong in the key. Both entry points forward it. 13 lines, no new plumbing.

## Compatibility

Leaving the flag unset produces byte-identical keys, so no existing series move
and no historical data is invalidated. Setting it starts a new series per
platform, which is the intent.

```
unset : ci.benchmarks.redislabs/by.hash/circleci/O/R/t/oss-standalone/<sha>/Ops/sec
m7    : ci.benchmarks.redislabs/by.hash/circleci/O/R/t/redisearch-m7/oss-standalone/<sha>/Ops/sec
metal : ci.benchmarks.redislabs/by.hash/circleci/O/R/t/redisearch-m7i-metal/oss-standalone/<sha>/Ops/sec
```

## Verification

Checked directly against the key-building helpers:

- `m7` and `m7i-metal` produce different keys
- unset produces a key byte-identical to before the change
- the label is present when set and absent when unset
- `--running_platform` parses in both `run-remote` and `run-local`

Caveat for reviewers: this was verified by exercising the pure key-building
helpers with third-party imports stubbed, not by running the project's own test
suite, which was not available in the environment used.

## Deliberately out of scope

`export_redis_metrics` is untouched. It builds its own key prefix for server-side
metrics, which are not used for regression gating, and changing that prefix would
relocate a separate metric family.

## Note for consumers

Callers pinning `redisbench_admin>=0.12.29` from PyPI will not have this flag
until it is released; passing it against a released version fails with
*unrecognized arguments*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
