### PR TITLE
ci: raise claude-pr-review max-turns 8 -> 20

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -154,7 +154,7 @@ jobs:
 
           claude_args: |
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*)"
-            --max-turns 8
+            --max-turns 20
             --json-schema '{"type":"object","properties":{"skip_comment":{"type":"boolean","description":"true if this routine/out-of-scope PR should get no comment at all"},"comment_body":{"type":"string","description":"The review comment text, empty string if skip_comment is true"}},"required":["skip_comment","comment_body"]}'
 
       - name: Post comment (only after a deterministic secret-pattern check)


### PR DESCRIPTION
Follow-up to #551.

The manual dry run (\`workflow_dispatch\` against PR #549) failed with
\`error_max_turns\` before Claude returned structured output -- 8 turns
wasn't enough to read the skill's SKILL.md + 2 reference files, then
the PR's diff/description, then compose the JSON response for a
non-trivial PR. No comment was posted; the workflow fails closed on
this exact case, so nothing leaked or partially posted.

Raising \`--max-turns\` from 8 to 20 rather than trimming what the skill
reads first, since grounding the review in the mined precedent is the
whole point.

Plan: merge, then re-run
\`gh workflow run claude-pr-review.yml -f pr_number=549\`.