### PR TITLE
ci: raise claude-pr-review max-turns 20 -> 35

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -154,7 +154,7 @@ jobs:
 
           claude_args: |
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*)"
-            --max-turns 20
+            --max-turns 35
             --json-schema '{"type":"object","properties":{"skip_comment":{"type":"boolean","description":"true if this routine/out-of-scope PR should get no comment at all"},"comment_body":{"type":"string","description":"The review comment text, empty string if skip_comment is true"}},"required":["skip_comment","comment_body"]}'
 
       - name: Post comment (only after a deterministic secret-pattern check)


### PR DESCRIPTION
Follow-up to #552 -- the dry run against PR #549 finished in 21 turns, one over the previous cap of 20 (the action fails even on a successful result if it exceeds --max-turns). Raising to 35 for real headroom. No comment was posted by either failed attempt; still fails closed.