### PR TITLE
ci: re-review on push (update-in-place) + workflow_dispatch for issue-triage

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -23,6 +23,16 @@ name: Claude Automated Issue Triage
 on:
   issues:
     types: [opened]
+  # Manual re-run for maintainer testing/verification only, e.g. exercising
+  # this workflow once against a pre-existing issue. GitHub restricts
+  # workflow_dispatch to actors with write access to this repo, so this
+  # doesn't widen who can trigger a run beyond the real trigger's audience.
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to run the triage against"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -32,7 +42,7 @@ permissions:
 jobs:
   claude-triage:
     # Skip the repo's own maintainers/members -- see header comment.
-    if: github.event.issue.author_association != 'OWNER' && github.event.issue.author_association != 'MEMBER' && github.event.issue.author_association != 'COLLABORATOR'
+    if: github.event_name == 'workflow_dispatch' || (github.event.issue.author_association != 'OWNER' && github.event.issue.author_association != 'MEMBER' && github.event.issue.author_association != 'COLLABORATOR')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -51,7 +61,7 @@ jobs:
 
           prompt: |
             REPO: ${{ github.repository }}
-            ISSUE NUMBER: ${{ github.event.issue.number }}
+            ISSUE NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
 
             Read this newly-opened issue's title and body via `gh issue view`.
 
@@ -105,7 +115,7 @@ jobs:
 
           claude_args: |
             --allowedTools "Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr list:*)"
-            --max-turns 6
+            --max-turns 35
             --json-schema '{"type":"object","properties":{"skip_comment":{"type":"boolean","description":"true if the issue is already clear/actionable and needs no comment"},"comment_body":{"type":"string","description":"The triage comment text, empty string if skip_comment is true"}},"required":["skip_comment","comment_body"]}'
 
       - name: Post comment (only after a deterministic secret-pattern check)
@@ -113,7 +123,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STRUCTURED_OUTPUT: ${{ steps.claude.outputs.structured_output }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -42,6 +42,16 @@ name: Claude Automated PR Review
 #     on this workflow -- per the action's own docs both can leak
 #     tokens/credentials into public step logs.
 #
+# Re-review on push: `synchronize` re-runs this on every commit pushed to the
+# PR (in addition to `opened`), so a push/review/iterate loop stays current.
+# This multiplies the "no rate limiting" residual risk below by every commit
+# pushed by anyone -- including fork contributors -- not just once per PR.
+# To avoid piling up one comment per push, the posting step below edits the
+# SAME comment in place (found by an invisible `<!-- claude-pr-review:auto -->`
+# marker written by the shell step, never by the model) instead of creating a
+# new one each time -- each edit reflects only the latest push's diff, not a
+# running log of every prior review.
+#
 # Residual risks not fully closed by the above (see PR description for the
 # full writeup): no volume/rate limiting on how many times this can fire
 # (set a spend alert on the API key); Claude Code's Bash allowlist matching
@@ -52,7 +62,7 @@ name: Claude Automated PR Review
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, synchronize]
   # Manual re-run for maintainer testing/verification only (e.g. exercising
   # this workflow once against an existing PR after merge, since a
   # pull_request_target workflow definition can't be pre-tested via a draft
@@ -163,6 +173,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STRUCTURED_OUTPUT: ${{ steps.claude.outputs.structured_output }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
@@ -172,7 +183,12 @@ jobs:
             exit 0
           fi
 
-          echo "$STRUCTURED_OUTPUT" | jq -r '.comment_body' > review_body.txt
+          # Deterministic marker, not model-controlled -- identifies our own
+          # comment across re-runs so a re-review updates it in place instead
+          # of piling up one comment per push.
+          MARKER="<!-- claude-pr-review:auto -->"
+          echo "$MARKER" > review_body.txt
+          echo "$STRUCTURED_OUTPUT" | jq -r '.comment_body' >> review_body.txt
 
           # Hard, deterministic gate -- independent of anything the model was told.
           # Known secret shapes for what THIS workflow has access to (Anthropic API
@@ -182,4 +198,13 @@ jobs:
             exit 1
           fi
 
-          gh pr comment "$PR_NUMBER" --body-file review_body.txt
+          EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            -q '.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("<!-- claude-pr-review:auto -->")) | .id' \
+            | tail -n1)
+
+          if [ -n "$EXISTING_ID" ]; then
+            echo "Updating prior automated review comment (id $EXISTING_ID) in place."
+            gh api "repos/$REPO/issues/comments/$EXISTING_ID" -X PATCH -f body=@review_body.txt >/dev/null
+          else
+            gh pr comment "$PR_NUMBER" --body-file review_body.txt
+          fi


### PR DESCRIPTION
Follow-up to #550/#551/#552/#553.

- `claude-pr-review.yml`: adds `synchronize` to the trigger types so pushing new commits to an open PR re-runs the review (push/review/iterate loop). The posting step now finds its own prior comment via a deterministic `<!-- claude-pr-review:auto -->` marker and PATCHes it in place instead of posting a new comment every push.
- `claude-issue-triage.yml`: adds the same `workflow_dispatch(issue_number)` manual-test path as claude-pr-review.yml, and bumps `--max-turns` 6 -> 35 for consistency.

Residual risk: `synchronize` multiplies the already-flagged 'anyone can trigger a paid run' risk by every commit pushed to any open PR, including from forks -- worth a spend alert on the Anthropic key if one isn't set yet.