### PR TITLE
search: SEARCH_CREATE_BEFORE_LOAD to control FT.CREATE-before-load ordering

### DIFF
--- a/redisbench_admin/run_local/local_db.py
+++ b/redisbench_admin/run_local/local_db.py
@@ -32,7 +32,11 @@ from redisbench_admin.utils.local import (
     check_dataset_local_requirements,
     is_process_alive,
 )
-from redisbench_admin.utils.utils import setup_search_clusterset, get_tmp_folder_rnd
+from redisbench_admin.utils.utils import (
+    setup_search_clusterset,
+    search_create_before_load,
+    get_tmp_folder_rnd,
+)
 
 
 def local_db_spin(
@@ -175,10 +179,11 @@ def local_db_spin(
     # Setup search CLUSTERSET if enabled (after all servers are started and cluster is set up)
     setup_search_clusterset(redis_conns, args.host, args.port, args.password)
 
-    # Run pre-steps before data loading when SEARCH_CLUSTERSET is set
-    if "SEARCH_CLUSTERSET" in os.environ:
+    # Run pre-steps before data loading when SEARCH_CREATE_BEFORE_LOAD is enabled
+    create_before_load = search_create_before_load()
+    if create_before_load:
         logging.info(
-            "SEARCH_CLUSTERSET is set. Running run_redis_pre_steps for each shard before data loading"
+            "SEARCH_CREATE_BEFORE_LOAD is enabled. Running run_redis_pre_steps for each shard before data loading"
         )
         for conn in redis_conns:
             artifact_version = run_redis_pre_steps(
@@ -246,8 +251,8 @@ def local_db_spin(
         )
     dbconfig_keyspacelen_check(benchmark_config, redis_conns, ignore_keyspace_errors)
 
-    # Only run pre_steps here if SEARCH_CLUSTERSET is not set (otherwise it was already run before data loading)
-    if "SEARCH_CLUSTERSET" not in os.environ:
+    # Only run pre_steps here if create-before-load is disabled (otherwise it was already run before data loading)
+    if not create_before_load:
         artifact_version = run_redis_pre_steps(
             benchmark_config, redis_conns[0], required_modules
         )

--- a/redisbench_admin/run_remote/remote_db.py
+++ b/redisbench_admin/run_remote/remote_db.py
@@ -5,7 +5,6 @@
 #
 import datetime
 import logging
-import os
 import redis
 
 from redisbench_admin.environments.oss_cluster import setup_redis_cluster_from_conns
@@ -37,7 +36,10 @@ from redisbench_admin.utils.remote import (
     check_dataset_remote_requirements,
     get_run_full_filename,
 )
-from redisbench_admin.utils.utils import setup_search_clusterset
+from redisbench_admin.utils.utils import (
+    setup_search_clusterset,
+    search_create_before_load,
+)
 
 
 def remote_tmpdir_prune(
@@ -318,10 +320,11 @@ def remote_db_spin(
         )
         for redis_conn in redis_conns:
             redis_conn.flushall()
-    # Run pre-steps before data loading when SEARCH_CLUSTERSET is set
-    if "SEARCH_CLUSTERSET" in os.environ:
+    # Run pre-steps before data loading when SEARCH_CREATE_BEFORE_LOAD is enabled
+    create_before_load = search_create_before_load()
+    if create_before_load:
         logging.info(
-            "SEARCH_CLUSTERSET is set. Running run_redis_pre_steps for each shard before data loading"
+            "SEARCH_CREATE_BEFORE_LOAD is enabled. Running run_redis_pre_steps for each shard before data loading"
         )
         for conn in redis_conns:
             artifact_version = run_redis_pre_steps(
@@ -443,8 +446,8 @@ def remote_db_spin(
         ignore_keyspace_errors,
         keyspace_check_timeout,
     )
-    # Only run pre_steps here if SEARCH_CLUSTERSET is not set (otherwise it was already run before data loading)
-    if "SEARCH_CLUSTERSET" not in os.environ:
+    # Only run pre_steps here if create-before-load is disabled (otherwise it was already run before data loading)
+    if not create_before_load:
         artifact_version = run_redis_pre_steps(
             benchmark_config, redis_conns[0], required_modules
         )

--- a/redisbench_admin/utils/utils.py
+++ b/redisbench_admin/utils/utils.py
@@ -160,6 +160,42 @@ def generate_common_server_args(
     return command
 
 
+# Values that explicitly disable a boolean env var. Any other non-empty value
+# enables it, keeping the "setting the var turns it on" convention used by the
+# other env vars in this module.
+FALSY_ENV_VALUES = {"", "0", "false", "no", "n", "off"}
+
+
+def env_flag(var_name):
+    """Tri-state read of a boolean environment variable.
+
+    Returns None when the var is unset so callers can tell "the user did not
+    express an opinion" apart from "the user explicitly disabled this".
+    """
+    value = os.getenv(var_name)
+    if value is None:
+        return None
+    return value.strip().lower() not in FALSY_ENV_VALUES
+
+
+def search_create_before_load():
+    """Whether dbconfig init_commands (FT.CREATE) run before the dataset loads.
+
+    When True the index is created on an empty keyspace and the loader indexes
+    incrementally as it writes; when False the data is loaded first and the
+    index backfills afterwards.
+
+    SEARCH_CREATE_BEFORE_LOAD decides it. If that var is unset we fall back to
+    the presence of SEARCH_CLUSTERSET, which used to be the only thing driving
+    this ordering, so existing SEARCH_CLUSTERSET runs are unaffected. Setting
+    SEARCH_CREATE_BEFORE_LOAD=0 opts out even under SEARCH_CLUSTERSET.
+    """
+    explicit = env_flag("SEARCH_CREATE_BEFORE_LOAD")
+    if explicit is not None:
+        return explicit
+    return os.getenv("SEARCH_CLUSTERSET") is not None
+
+
 def setup_search_clusterset(
     redis_conns, host="127.0.0.1", start_port=6379, password=None
 ):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,8 @@ from redisbench_admin.utils.utils import (
     retrieve_local_or_remote_input_json,
     get_ts_metric_name,
     get_remote_input_file_from_url,
+    env_flag,
+    search_create_before_load,
 )
 
 
@@ -153,3 +155,47 @@ def test_get_remote_input_file_from_url():
     # Test with .dat extension
     url = "https://s3.amazonaws.com/data/benchmark_data.dat"
     assert get_remote_input_file_from_url(url) == "/tmp/input-benchmark_data.data"
+
+
+def test_env_flag(monkeypatch):
+    # unset is a distinct third state, not False
+    monkeypatch.delenv("SOME_FLAG", raising=False)
+    assert env_flag("SOME_FLAG") is None
+
+    for enabled in ["1", "true", "TRUE", "yes", "y", "on", "  True  ", "whatever"]:
+        monkeypatch.setenv("SOME_FLAG", enabled)
+        assert env_flag("SOME_FLAG") is True, enabled
+
+    for disabled in ["0", "false", "FALSE", "no", "n", "off", "", "  0  "]:
+        monkeypatch.setenv("SOME_FLAG", disabled)
+        assert env_flag("SOME_FLAG") is False, disabled
+
+
+def test_search_create_before_load_defaults_off(monkeypatch):
+    monkeypatch.delenv("SEARCH_CREATE_BEFORE_LOAD", raising=False)
+    monkeypatch.delenv("SEARCH_CLUSTERSET", raising=False)
+    assert search_create_before_load() is False
+
+
+def test_search_create_before_load_inherits_search_clusterset(monkeypatch):
+    # backwards compatibility: SEARCH_CLUSTERSET used to be the only thing
+    # driving the create-index-then-load ordering, and it is presence-based
+    monkeypatch.delenv("SEARCH_CREATE_BEFORE_LOAD", raising=False)
+    for clusterset in ["1", "yes", ""]:
+        monkeypatch.setenv("SEARCH_CLUSTERSET", clusterset)
+        assert search_create_before_load() is True, clusterset
+
+
+def test_search_create_before_load_standalone(monkeypatch):
+    # the whole point of the new var: enable the ordering without SEARCH_CLUSTERSET
+    monkeypatch.delenv("SEARCH_CLUSTERSET", raising=False)
+    monkeypatch.setenv("SEARCH_CREATE_BEFORE_LOAD", "1")
+    assert search_create_before_load() is True
+
+
+def test_search_create_before_load_explicit_opt_out(monkeypatch):
+    # an explicit disable wins over the SEARCH_CLUSTERSET fallback
+    monkeypatch.setenv("SEARCH_CLUSTERSET", "1")
+    for disabled in ["0", "false", "no", "off"]:
+        monkeypatch.setenv("SEARCH_CREATE_BEFORE_LOAD", disabled)
+        assert search_create_before_load() is False, disabled


### PR DESCRIPTION
## Why

*When* `dbconfig.init_commands` (in practice, `FT.CREATE`) runs relative to data
loading was implicitly tied to `SEARCH_CLUSTERSET`: setting that var moved the
pre-steps ahead of the load, and there was no way to get one without the other.
So getting `FT.CREATE` onto an empty keyspace — letting the loader index
incrementally as it writes, rather than having the index backfill afterwards —
meant opting into clusterset configuration you may not want.

This splits the ordering decision out into its own switch.

## How

New `SEARCH_CREATE_BEFORE_LOAD` env var, resolved by `search_create_before_load()`
in `redisbench_admin/utils/utils.py`:

| `SEARCH_CREATE_BEFORE_LOAD` | `SEARCH_CLUSTERSET` | pre-steps run |
| --- | --- | --- |
| truthy (`1`/`true`/`yes`/`on`/…) | anything | before load, on every shard |
| falsy (`0`/`false`/`no`/`off`/`""`) | anything | after load, on `redis_conns[0]` |
| unset | set | before load, on every shard |
| unset | unset | after load, on `redis_conns[0]` |

- The unset-fallback is deliberately **presence**-based on `SEARCH_CLUSTERSET`,
  matching the `"SEARCH_CLUSTERSET" in os.environ` checks it replaces and
  `setup_search_clusterset()`, so existing clusterset runs are unaffected.
- `env_flag()` is a tri-state reader (`None` when unset), which is what lets an
  explicit `SEARCH_CREATE_BEFORE_LOAD=0` opt out even under `SEARCH_CLUSTERSET`.
- Both call sites (`local_db_spin`, `remote_db_spin`) now read the flag **once**
  into a local rather than re-checking `os.environ` twice, so the before-load and
  after-load branches can't disagree if the environment mutates mid-run.
- `import os` dropped from `remote_db.py` — those two checks were its only use.

## Scope

This only affects ordering relative to the **client-tool** (`dbconfig`) loading
path. An RDB `dataset` still lands first either way: locally it is loaded at
Redis spin-up, and remotely `DEBUG RELOAD NOSAVE` runs after the pre-steps.

Also worth knowing: in the before-load ordering, `search_specific_init`'s
`ft._list` wait runs against an empty keyspace and returns immediately, so there
is no post-load gate on index completeness in that branch.

## Testing

5 new cases in `tests/test_utils.py` cover the tri-state reader, the recognised
value sets, the `SEARCH_CLUSTERSET` fallback, standalone enablement, and the
explicit opt-out. `black` and `flake8` clean.

`test_run_local.py`, `test_local.py`, `test_remote_db.py`, `test_utils.py`:
26 passed, 3 failed. The 3 failures (`test_run_local_dataset_reuse_*`) reproduce
identically with this change stashed, so they are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
