### PR TITLE
exporter: push results to RedisTimeSeries in two round trips

### DIFF
--- a/redisbench_admin/utils/remote.py
+++ b/redisbench_admin/utils/remote.py
@@ -18,7 +18,6 @@ import redis
 from git import Repo
 from jsonpath_ng import parse
 from python_terraform import Terraform
-from tqdm import tqdm
 
 from redisbench_admin.environments.oss_cluster import get_cluster_dbfilename
 from redisbench_admin.run.metrics import extract_results_table
@@ -777,68 +776,156 @@ def fetch_remote_setup_from_config(
     return terraform_working_dir, setup_type, setup
 
 
+def _prepare_timeseries_entries(time_series_dict: dict):
+    """Resolve final key names and labels without touching the network.
+
+    Two things the push has to settle before it can write, both of which used to
+    happen inside the per-series round-trip loop:
+
+    * labels whose value is None cannot be sent, so they are dropped here rather
+      than failing the TS.CREATE.
+    * an aarch64 series whose key does not already say so gets the architecture
+      appended, so the two architectures do not share one series.
+    """
+    entries = []
+    for timeseries_name, time_series in time_series_dict.items():
+        final_labels = {}
+        for label_name, value in time_series.get("labels", {}).items():
+            if value is not None:
+                final_labels[label_name] = value
+            else:
+                logging.warning(
+                    f"The label {label_name} value was None. skipping it..."
+                )
+        time_series["labels"] = final_labels
+
+        arch = final_labels.get("arch", "x86_64")
+        if arch == "aarch64" and "aarch64" not in timeseries_name:
+            original_timeseries_name = timeseries_name
+            timeseries_name = f"{timeseries_name}/arch/{arch}"
+            logging.warning(
+                f"overriding key named {original_timeseries_name} given it does not "
+                f"contain arch and it's not x86_64. new key={timeseries_name}"
+            )
+        entries.append((timeseries_name, time_series))
+    return entries
+
+
 def push_data_to_redistimeseries(rts, time_series_dict: dict, expire_msecs=0):
+    """Write every series and datapoint in two round trips.
+
+    This used to cost 2-4 round trips *per series*: EXISTS, then TS.INFO to
+    compare labels or TS.CREATE, then one TS.ADD per datapoint, then an optional
+    PEXPIRE -- all sequential. That is only cheap when the exporter is next to
+    the database. Measured against a remote RedisTimeSeries at 108 ms RTT, one
+    benchmark's 8 datapoints took 6.0 s in ~28 sequential round trips.
+
+    The obstacle to batching was the conditional: you cannot pipeline
+    "TS.CREATE only if it does not exist" because the decision needs the answer.
+    So the work is split at the decision instead:
+
+      1. one pipelined TS.INFO per series -- a missing key comes back as a
+         ResponseError inside the results rather than raising, which is the same
+         signal EXISTS was being spent on, so EXISTS is no longer needed.
+      2. one pipeline carrying every TS.CREATE, TS.ALTER, TS.ADD and PEXPIRE.
+
+    Two round trips total, independent of how many series there are.
+
+    Errors are read out of the pipeline results rather than caught per call, so
+    the returned (errors, inserts) counts keep the same meaning: a partial
+    failure must not be able to look like a clean push.
+    """
     datapoint_errors = 0
     datapoint_inserts = 0
-    if rts is not None and time_series_dict is not None:
-        progress = tqdm(
-            unit="benchmark time-series", total=len(time_series_dict.values())
-        )
-        for timeseries_name, time_series in time_series_dict.items():
-            try:
-                arch = "x86_64"
-                if "arch" in time_series["labels"]:
-                    arch = time_series["labels"]["arch"]
-                if arch == "aarch64" and "aarch64" not in timeseries_name:
-                    original_timeseries_name = timeseries_name
-                    timeseries_name = f"{timeseries_name}/arch/{arch}"
-                    logging.warning(
-                        f"overriding key named {original_timeseries_name} given it does not contain arch and it's not x86_64. new key={timeseries_name}"
+    if rts is None or time_series_dict is None:
+        return datapoint_errors, datapoint_inserts
+
+    entries = _prepare_timeseries_entries(time_series_dict)
+    if len(entries) == 0:
+        return datapoint_errors, datapoint_inserts
+
+    # --- round trip 1: which series exist, and with which labels ---
+    probe = rts.ts().pipeline(transaction=False)
+    for timeseries_name, _ in entries:
+        probe.info(timeseries_name)
+    infos = probe.execute(raise_on_error=False)
+
+    # --- round trip 2: create or realign, then write every datapoint ---
+    writer = rts.ts().pipeline(transaction=False)
+    # what each queued command was, so a failure can be attributed and counted
+    planned = []
+    for (timeseries_name, time_series), info in zip(entries, infos):
+        labels = time_series["labels"]
+        if isinstance(info, Exception):
+            logging.debug(
+                "Creating timeseries named {} with labels {}".format(
+                    timeseries_name, labels
+                )
+            )
+            writer.create(timeseries_name, labels=labels, chunk_size=128)
+            planned.append(("create", timeseries_name, None))
+        else:
+            existing_labels = dict(getattr(info, "labels", None) or {})
+            if existing_labels != labels:
+                logging.info(
+                    "Given the labels don't match using TS.ALTER on {} to update "
+                    "labels to {}".format(timeseries_name, labels)
+                )
+                writer.alter(timeseries_name, labels=labels)
+                planned.append(("alter", timeseries_name, None))
+
+        for timestamp, value in time_series.get("data", {}).items():
+            if timestamp is None:
+                # "*" is the auto-timestamp form. Passing the value where the
+                # timestamp belongs, as this branch used to, drops the value
+                # argument entirely and raises TypeError -- which the old
+                # per-call handler did not catch.
+                logging.warning("The provided timestamp is null. Using auto-ts")
+                writer.add(timeseries_name, "*", value, duplicate_policy="last")
+            else:
+                writer.add(timeseries_name, timestamp, value, duplicate_policy="last")
+            planned.append(("add", timeseries_name, (timestamp, value)))
+
+        if expire_msecs > 0:
+            writer.pexpire(timeseries_name, expire_msecs)
+            planned.append(("pexpire", timeseries_name, None))
+
+    results = writer.execute(raise_on_error=False)
+
+    for (kind, timeseries_name, datapoint), result in zip(planned, results):
+        if isinstance(result, Exception):
+            if kind == "add":
+                timestamp, value = datapoint
+                logging.warning(
+                    "Error while inserting datapoint ({} : {}) in timeseries "
+                    "named {}. {}".format(
+                        timestamp, value, timeseries_name, result.__str__()
                     )
-                exporter_create_ts(rts, time_series, timeseries_name)
-                for timestamp, value in time_series["data"].items():
-                    try:
-                        if timestamp is None:
-                            logging.warning(
-                                "The provided timestamp is null. Using auto-ts"
-                            )
-                            rts.ts().add(
-                                timeseries_name,
-                                value,
-                                duplicate_policy="last",
-                            )
-                        else:
-                            rts.ts().add(
-                                timeseries_name,
-                                timestamp,
-                                value,
-                                duplicate_policy="last",
-                            )
-                        datapoint_inserts += 1
-                    except redis.exceptions.DataError:
-                        logging.warning(
-                            "Error while inserting datapoint ({} : {}) in timeseries named {}. ".format(
-                                timestamp, value, timeseries_name
-                            )
-                        )
-                        datapoint_errors += 1
-                        pass
-                    except redis.exceptions.ResponseError:
-                        logging.warning(
-                            "Error while inserting datapoint ({} : {}) in timeseries named {}. ".format(
-                                timestamp, value, timeseries_name
-                            )
-                        )
-                        datapoint_errors += 1
-                        pass
-                if expire_msecs > 0:
-                    rts.pexpire(timeseries_name, expire_msecs)
-            except redis.exceptions.TimeoutError:
-                logging.error(
-                    f"Error while working in timeseries named {timeseries_name}. "
                 )
                 datapoint_errors += 1
-            progress.update()
+            else:
+                logging.error(
+                    "Error on TS.{} for timeseries named {}: {}".format(
+                        kind.upper(), timeseries_name, result.__str__()
+                    )
+                )
+        elif kind == "add":
+            datapoint_inserts += 1
+
+    logging.info(
+        "Pushed {} datapoint(s) across {} series in 2 round trips ({} error(s)).".format(
+            datapoint_inserts, len(entries), datapoint_errors
+        )
+    )
+
+    if len(results) != len(planned):
+        # A truncated reply means commands we queued were never answered, so the
+        # counts above understate what happened. Loud rather than silent.
+        logging.error(
+            "Pipeline returned {} results for {} queued commands; some writes "
+            "are unaccounted for.".format(len(results), len(planned))
+        )
+
     return datapoint_errors, datapoint_inserts
 
 
@@ -1259,7 +1346,7 @@ def extract_perbranch_timeseries_from_results(
 ):
     break_by_key = "branch"
     break_by_str = "by.{}".format(break_by_key)
-    (branch_time_series_dict, target_tables) = common_timeseries_extraction(
+    branch_time_series_dict, target_tables = common_timeseries_extraction(
         break_by_key,
         break_by_str,
         datapoints_timestamp,
@@ -1301,7 +1388,7 @@ def extract_perhash_timeseries_from_results(
 ):
     break_by_key = "hash"
     break_by_str = "by.{}".format(break_by_key)
-    (hash_time_series_dict, target_tables) = common_timeseries_extraction(
+    hash_time_series_dict, target_tables = common_timeseries_extraction(
         break_by_key,
         break_by_str,
         datapoints_timestamp,

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -834,3 +834,163 @@ def test_get_run_full_filename_branch_with_multiple_slashes():
     )
     assert "/" not in result
     assert "feat-area-thing" in result
+
+
+# --------------------------------------------------------------------------- #
+# push_data_to_redistimeseries: two round trips, whatever the series count
+# --------------------------------------------------------------------------- #
+class _FakeInfo:
+    def __init__(self, labels):
+        self.labels = labels
+
+
+class _FakePipeline:
+    """Records what was queued and hands back programmed results."""
+
+    def __init__(self, owner):
+        self.owner = owner
+        self.queued = []
+
+    def info(self, key):
+        self.queued.append(("info", key))
+        return self
+
+    def create(self, key, **kwargs):
+        self.queued.append(("create", key, kwargs))
+        return self
+
+    def alter(self, key, **kwargs):
+        self.queued.append(("alter", key, kwargs))
+        return self
+
+    def add(self, key, timestamp, value, **kwargs):
+        self.queued.append(("add", key, timestamp, value))
+        return self
+
+    def pexpire(self, key, msecs):
+        self.queued.append(("pexpire", key, msecs))
+        return self
+
+    def execute(self, raise_on_error=True):
+        self.owner.executions.append(list(self.queued))
+        results = []
+        for cmd in self.queued:
+            kind, key = cmd[0], cmd[1]
+            if kind == "info":
+                if key in self.owner.existing:
+                    results.append(_FakeInfo(dict(self.owner.existing[key])))
+                else:
+                    results.append(
+                        redis.exceptions.ResponseError("TSDB: the key does not exist")
+                    )
+            elif kind == "add" and key in self.owner.failing_adds:
+                results.append(redis.exceptions.ResponseError("TSDB: rejected"))
+            else:
+                results.append(True)
+        return results
+
+
+class _FakeTSNamespace:
+    def __init__(self, owner):
+        self.owner = owner
+
+    def pipeline(self, transaction=True):
+        return _FakePipeline(self.owner)
+
+
+class _FakeRTS:
+    def __init__(self, existing=None, failing_adds=()):
+        self.existing = existing or {}
+        self.failing_adds = set(failing_adds)
+        self.executions = []
+
+    def ts(self):
+        return _FakeTSNamespace(self)
+
+
+def _series(labels, data):
+    return {"labels": dict(labels), "data": dict(data)}
+
+
+def test_push_uses_two_round_trips_regardless_of_series_count():
+    for n_series in (1, 5, 40):
+        tsd = {
+            f"key/{i}": _series({"arch": "x86_64"}, {1000 + i: float(i)})
+            for i in range(n_series)
+        }
+        rts = _FakeRTS()
+        errors, inserts = push_data_to_redistimeseries(rts, tsd)
+        assert errors == 0
+        assert inserts == n_series
+        # the whole point: cost does not scale with the number of series
+        assert (
+            len(rts.executions) == 2
+        ), f"{n_series} series took {len(rts.executions)} round trips"
+
+
+def test_push_creates_missing_and_skips_create_for_existing():
+    labels = {"arch": "x86_64", "test_name": "t"}
+    tsd = {
+        "exists/1": _series(labels, {1000: 1.0}),
+        "missing/1": _series(labels, {1000: 2.0}),
+    }
+    rts = _FakeRTS(existing={"exists/1": labels})
+    errors, inserts = push_data_to_redistimeseries(rts, tsd)
+    assert (errors, inserts) == (0, 2)
+    writer = rts.executions[1]
+    kinds = [(c[0], c[1]) for c in writer]
+    assert ("create", "missing/1") in kinds
+    assert ("create", "exists/1") not in kinds
+    # matching labels must not trigger a needless TS.ALTER
+    assert ("alter", "exists/1") not in kinds
+
+
+def test_push_alters_when_labels_drifted():
+    tsd = {"k": _series({"arch": "x86_64", "branch": "new"}, {1000: 1.0})}
+    rts = _FakeRTS(existing={"k": {"arch": "x86_64", "branch": "old"}})
+    push_data_to_redistimeseries(rts, tsd)
+    kinds = [(c[0], c[1]) for c in rts.executions[1]]
+    assert ("alter", "k") in kinds
+
+
+def test_push_counts_failed_datapoints_rather_than_reporting_success():
+    tsd = {
+        "good": _series({}, {1000: 1.0}),
+        "bad": _series({}, {1000: 2.0, 2000: 3.0}),
+    }
+    rts = _FakeRTS(failing_adds={"bad"})
+    errors, inserts = push_data_to_redistimeseries(rts, tsd)
+    assert errors == 2, "both rejected datapoints must be counted"
+    assert inserts == 1
+
+
+def test_push_drops_none_labels_and_qualifies_aarch64_keys():
+    tsd = {
+        "plain/key": _series({"arch": "aarch64", "empty": None}, {1000: 1.0}),
+        "already/aarch64/key": _series({"arch": "aarch64"}, {1000: 1.0}),
+    }
+    rts = _FakeRTS()
+    push_data_to_redistimeseries(rts, tsd)
+    created = {c[1]: c[2]["labels"] for c in rts.executions[1] if c[0] == "create"}
+    assert "plain/key/arch/aarch64" in created, created
+    assert (
+        "already/aarch64/key" in created
+    ), "key already naming the arch must not be rewritten"
+    assert "empty" not in created["plain/key/arch/aarch64"]
+
+
+def test_push_auto_timestamp_sends_star_not_the_value():
+    tsd = {"k": _series({}, {None: 7.5})}
+    rts = _FakeRTS()
+    errors, inserts = push_data_to_redistimeseries(rts, tsd)
+    assert (errors, inserts) == (0, 1)
+    adds = [c for c in rts.executions[1] if c[0] == "add"]
+    assert adds == [("add", "k", "*", 7.5)], adds
+
+
+def test_push_is_a_noop_without_client_or_data():
+    assert push_data_to_redistimeseries(None, {"k": _series({}, {1: 1.0})}) == (0, 0)
+    assert push_data_to_redistimeseries(_FakeRTS(), None) == (0, 0)
+    rts = _FakeRTS()
+    assert push_data_to_redistimeseries(rts, {}) == (0, 0)
+    assert rts.executions == [], "an empty push must not talk to the database"


### PR DESCRIPTION
## Why

Exporting one benchmark's results cost **6.0 s for 8 datapoints** against a
remote RedisTimeSeries — roughly **28 sequential round trips at 108 ms each**.

The exporter spent 2–4 round trips *per time series*, in order:

```
EXISTS name                        1 RTT   every series, every push
  ├─ check_rts_labels: TS.INFO     1 RTT   if it exists (the normal case)
  │    └─ TS.ALTER                 1 RTT   whenever labels differ
  └─ TS.CREATE                     1 RTT   first time only
TS.ADD                             1 RTT   per datapoint
PEXPIRE                            1 RTT   when expire_msecs > 0
```

Measured decomposition of one `search-numeric-sortby` push (RTT 108 ms):

| | |
| --- | --- |
| `push_data_to_redistimeseries` | 2.6 s |
| target tables | 1.7 s |
| extra metrics (`benchmark_duration`, `dataset_load_duration`) | ~1.1 s |

This PR addresses the first row. The other two are the same pattern in
`run/redistimeseries.py` and can follow if this shape is agreed.

## How

Pipelining was blocked by a conditional — you cannot batch "TS.CREATE only if it
does not exist", because the decision needs the answer. So the split is at the
decision, not at the series:

1. **one pipelined `TS.INFO` per series.** A missing key returns a
   `ResponseError` *inside* the results rather than raising, which is the same
   signal `EXISTS` was being spent on — so `EXISTS` is gone. Verified against a
   real RedisTimeSeries: existing series return `TSInfo`, missing ones and
   non-timeseries keys return `ResponseError` in the result list.
2. **one pipeline** carrying every `TS.CREATE`, `TS.ALTER`, `TS.ADD` and
   `PEXPIRE`.

**Two round trips, independent of series count.**

Errors are read out of the pipeline results instead of caught per call, so
`(datapoint_errors, datapoint_inserts)` keep their meaning — a partial failure
must not be able to look like a clean push. A reply shorter than the queued
commands is logged as an error rather than silently undercounting.

### Drive-by fix

The null-timestamp branch called

```python
rts.ts().add(timeseries_name, value, duplicate_policy="last")
```

against `add(key, timestamp, value)`. The value landed in the timestamp position
and `value` was missing — a `TypeError`, which the surrounding
`except (DataError, ResponseError)` did not catch. The auto-timestamp form is
`"*"`.

## Scope

`exporter_create_ts` and `check_rts_labels` are unchanged and still used by
`run/redistimeseries.py`. The per-series `tqdm` bar is replaced by a single
completion line — there is nothing to tick when the push is two commands.

## Testing

New tests use a fake pipeline rather than a live server, so they run in CI. They
pin the round-trip count at **2 for 1, 5 and 40 series**, and cover
create-vs-skip, label drift, failed-datapoint accounting, `None`-label dropping,
the aarch64 key rewrite, the auto-timestamp form, and the no-op paths.

`tests/test_remote.py`: **24 passed, 3 skipped**. `black` and `flake8` clean.

`tests/test_common.py` has 3 failures (`test_common_exporter_logic`,
`test_dbconfig_keyspacelen_check`, `test_execute_init_and_post_commands`) — all
`assert 'RTS_PORT' in environ`. I reproduced them identically on unmodified
`master` in a separate worktree, so they are pre-existing and environmental.

## Not yet measured end to end

Draft because the win is so far arithmetic (28 round trips → 2) plus unit tests,
not an observed wall-clock improvement on a real run. Worth noting the honest
scale: at ~6 s per spec, 9 specs per repetition and repetitions running 5-wide,
this is roughly **2 minutes out of a 2–3 hour benchmark run**. It is a real
inefficiency that grows with spec count, not a fix for the dominant cost — which
is the sequential per-spec dataset load plus measurement.
